### PR TITLE
Added day and month to watchface with toggle settings

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -7,9 +7,16 @@ clock.granularity = 'seconds';
 let hourHand = document.getElementById('hours'),
   minHand = document.getElementById('mins'),
   secHand = document.getElementById('secs'),
-  myDate = document.getElementById('myDate'),
+  date = document.getElementById('date'),
+  month = document.getElementById('month'),
   middle = document.getElementById('middle'),
-  secsRect = document.getElementById('secsRect');
+  secsRect = document.getElementById('secsRect'),
+  days = ["SUN", "MON", "TUE", "WED", "THUR", "FRI", "SAT"],
+  months = ["JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"];
+
+var showDay = false,
+    showDate = true,
+    showMonth = false;
 
 function hoursToAngle(hours, minutes) {
   let hourAngle = 360 / 12 * hours,
@@ -29,10 +36,27 @@ function updateClock() {
   let today = new Date(),
     hours = today.getHours() % 12,
     mins = today.getMinutes(),
-    secs = today.getSeconds();
+    secs = today.getSeconds(),
+    dateText = '';
 
-  myDate.text = today.getDate();
-
+  
+  //
+  if(showDay) {
+    dateText = dateText += days[today.getDay()]
+  } 
+  
+  if(showDate){
+     dateText = dateText + ' ' + today.getDate();
+  }
+  
+  date.text = dateText;
+  
+  if(showMonth){
+    month.text = months[today.getMonth()];
+  } else {
+    month.text = "";
+  }
+  
   hourHand.groupTransform.rotate.angle = hoursToAngle(hours, mins);
   minHand.groupTransform.rotate.angle = minutesToAngle(mins);
   secHand.groupTransform.rotate.angle = secondsToAngle(secs);
@@ -45,6 +69,19 @@ messaging.peerSocket.onmessage = evt => {
     let color = JSON.parse(evt.data.newValue);
     middle.style.fill = color;
     secsRect.style.fill = color;
-    myDate.style.fill = color;
+    date.style.fill = color;
+    //myDay.style.fill = color;
   }
+  
+  if (evt.data.key === 'showDay' && evt.data.newValue) {
+    showDay = JSON.parse(evt.data.newValue);
+  }
+  
+  if (evt.data.key === 'showDate' && evt.data.newValue) {
+    showDate = JSON.parse(evt.data.newValue);
+  }
+  
+  if (evt.data.key === 'showMonth' && evt.data.newValue) {
+    showMonth = JSON.parse(evt.data.newValue);
+  }  
 };

--- a/companion/index.js
+++ b/companion/index.js
@@ -32,3 +32,8 @@ settingsStorage.onchange = evt => {
   };
   sendVal(data);
 };
+
+
+settingsStorage.setItem('showDate', 'true') ;
+settingsStorage.setItem('showDay', 'false') ;
+settingsStorage.setItem('showMonth', 'true') ;

--- a/resources/index.gui
+++ b/resources/index.gui
@@ -1,7 +1,10 @@
 <svg viewport-fill="#111111">
   <image href="face.png" />
-  <text id="myDate" x="50%+90" y="50%+12"
-      fill="#f83c40" font-size="32" font-family="System-Bold"
+  <text id="month" x="18%" y="50%+7"
+      fill="#f83c40" font-size="24" font-family="System-Bold"
+      text-anchor="start" text-length="20"></text>
+  <text id="date" x="50%+100" y="50%+7"
+      fill="#f83c40" font-size="24" font-family="System-Bold"
       text-anchor="end" text-length="20"></text>
   <circle cx="50%" cy="50%" r="10" fill="#ffffff" />
   <g id="mins" pointer-events="visible" transform="translate(50%,50%)">

--- a/settings/index.jsx
+++ b/settings/index.jsx
@@ -28,8 +28,22 @@ function mySettings(props) {
           ]}
         />
       </Section>
+      <Section
+        title={<Text bold align="center">Date settings</Text>}>
+        <Toggle
+          settingsKey="showDate"
+          label={"Show Date"}
+        />
+        <Toggle
+          settingsKey="showDay"
+          label={"Show Day"}
+        />
+        <Toggle
+          settingsKey="showMonth"
+          label={"Show Month"}
+        />        
+      </Section>      
     </Page>
   );
 }
-
 registerSettingsPage(mySettings);


### PR DESCRIPTION
Not sure if you are interested in integrating these changes into the watch face or not, but I wanted to send them back your way if you are. 

I added the month on the left side of the watch face and the day name on the right along with the date. I also added toggles for all three settings. The default settings display only the date, as the watchface was originally intended. The new changes are also tied to the accent color setting. 

Thank you again for sharing your code.